### PR TITLE
Correctly handle missing container statuses

### DIFF
--- a/dist/object-describer.js
+++ b/dist/object-describer.js
@@ -233,7 +233,7 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
 
 
   $templateCache.put('views/container-statuses.html',
-    "<div ng-if=\"containerStatuses.length == 0\"><em>none</em></div>\n" +
+    "<div ng-if=\"!containerStatuses\"><em>none</em></div>\n" +
     "<dl ng-repeat=\"containerStatus in containerStatuses | orderBy:'name'\" class=\"dl-horizontal\">\n" +
     "  <dt>Name</dt>\n" +
     "  <dd>{{containerStatus.name}}</dd>\n" +

--- a/views/container-statuses.html
+++ b/views/container-statuses.html
@@ -1,4 +1,4 @@
-<div ng-if="containerStatuses.length == 0"><em>none</em></div>
+<div ng-if="!containerStatuses"><em>none</em></div>
 <dl ng-repeat="containerStatus in containerStatuses | orderBy:'name'" class="dl-horizontal">
   <dt>Name</dt>
   <dd>{{containerStatus.name}}</dd>


### PR DESCRIPTION
Container statuses are omitted from the response when empty.

https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/api/v1beta3/types.go#L853
