### PR TITLE
views: Don't show 'Namespace' if no namespace metadata

### DIFF
--- a/dist/object-describer.js
+++ b/dist/object-describer.js
@@ -316,8 +316,8 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
     "<dl class=\"dl-horizontal\">\n" +
     "  <dt>Name</dt>\n" +
     "  <dd>{{resource.metadata.name}}</dd>\n" +
-    "  <dt>Namespace</dt>\n" +
-    "  <dd>{{resource.metadata.namespace}}</dd>\n" +
+    "  <dt ng-if=\"resource.metadata.namespace\">Namespace</dt>\n" +
+    "  <dd ng-if=\"resource.metadata.namespace\">{{resource.metadata.namespace}}</dd>\n" +
     "  <dt>Created</dt>\n" +
     "  <dd>{{resource.metadata.creationTimestamp | date:'medium'}}</dd>    \n" +
     "</dl>\n" +

--- a/views/metadata.html
+++ b/views/metadata.html
@@ -1,8 +1,8 @@
 <dl class="dl-horizontal">
   <dt>Name</dt>
   <dd>{{resource.metadata.name}}</dd>
-  <dt>Namespace</dt>
-  <dd>{{resource.metadata.namespace}}</dd>
+  <dt ng-if="resource.metadata.namespace">Namespace</dt>
+  <dd ng-if="resource.metadata.namespace">{{resource.metadata.namespace}}</dd>
   <dt>Created</dt>
   <dd>{{resource.metadata.creationTimestamp | date:'medium'}}</dd>    
 </dl>


### PR DESCRIPTION
Some objects like Nodes or Namespaces themselves don't have
a namespace in their metadata.  This breaks the layout, since
there's a missing value in the dd column.

Hide the Namespace dt when this no namespace is available.
