### PR TITLE
Revealable text fields, both expanding and masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Theme
 
 The example theme used in `index.html` is based on bootstrap, however bootstrap is not required as a bower dependency and you can change the theme however you want.
 
+Certain functionality requires CSS, and CSS snippets have been provided. These are generally style agnostic.
+
 Optional Features
 -----------------
 

--- a/dist/object-describer.js
+++ b/dist/object-describer.js
@@ -141,7 +141,12 @@ angular.module('kubernetesUI')
     scope: {
       containers: '='
     },
-    templateUrl: 'views/containers.html'
+    templateUrl: 'views/containers.html',
+    link: function($scope, element, attrs) {
+      $scope.shouldMask = function(name) {
+          return name.toLowerCase().indexOf('password') !== -1;
+      };
+    }
   }
 })
 .directive("kubernetesObjectDescribeContainerStatuses", function() {
@@ -162,26 +167,19 @@ angular.module('kubernetesUI')
     templateUrl: 'views/container-state.html'
   };
 })
-.directive("collapseLongText", function() {
+.directive("revealableText", function() {
   return {
     restrict: 'A',
-    scope: {
-      value: '@',
-      enableCollapse: '=?' // not intended to be passed in, it will be set depending on jquery availability
-    },
-    controller: ["$scope", function($scope) {
-      // If jquery is available
-      $scope.enableCollapse = !!window.$;
-    }],
     link: function($scope, element, attrs) {
-      if ($scope.enableCollapse) {
-        $('.reveal-contents-link', element).click(function (evt) {
-          $(this).hide();
-          $('.reveal-contents', element).show();
-        });  
-      }
-    },    
-    templateUrl: 'views/_collapse-long-text.html'
+      element.addClass('revealable');
+      $(element).on("mouseover", function() {
+        var clickable = element[0].scrollWidth > element[0].clientWidth || element.find(".masked")[0];
+        element.toggleClass("clickable", clickable);
+      });
+      $(element).on("click", function() {
+        element.toggleClass("revealed");
+      });
+    }
   }
 })
 .filter("isEmptyObj", function() {
@@ -193,28 +191,19 @@ angular.module('kubernetesUI')
 angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
   'use strict';
 
-  $templateCache.put('views/_collapse-long-text.html',
-    "<span ng-hide=\"enableCollapse && value.length > 120\">{{value}}</span>\n" +
-    "<span ng-show=\"enableCollapse && value.length > 120\">\n" +
-    "  <span class=\"reveal-contents-link\" style=\"cursor: pointer;\" title=\"Expand\">{{value.substring(0, 120)}}<a href=\"javascript:;\">...</a></span>\n" +
-    "  <span style=\"display: none;\" class=\"reveal-contents\">{{value}}</span>\n" +
-    "</span>"
-  );
-
-
   $templateCache.put('views/annotations.html',
     "  <h3>Annotations</h3>\n" +
     "  <span ng-if=\"!resource.metadata.annotations\"><em>none</em></span>\n" +
     "  <dl class=\"dl-horizontal\" ng-if=\"resource.metadata.annotations\">\n" +
     "    <dt ng-repeat-start=\"(annotationKey, annotationValue) in resource.metadata.annotations\" title=\"{{annotationKey}}\">{{annotationKey}}</dt>\n" +
-    "    <dd ng-repeat-end collapse-long-text value=\"{{annotationValue}}\"></dd>\n" +
-    "  </dl>"
+    "    <dd ng-repeat-end revealable-text>{{annotationValue}}</dd>\n" +
+    "  </dl>\n"
   );
 
 
   $templateCache.put('views/container-state.html',
     "<span ng-if=\"containerState | isEmptyObj\"><em>none</em></span>\n" +
-    "<span ng-repeat=\"(state, stateDescription) in containerState | limitTo: 1\">\n" +
+    "<span ng-repeat=\"(state, stateDescription) in containerState | limitTo: 1\" revealable-text>\n" +
     "  <span ng-switch=\"state\">\n" +
     "    <span ng-switch-when=\"waiting\">\n" +
     "      Waiting\n" +
@@ -240,7 +229,7 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
     "<div ng-if=\"!containerStatuses\"><em>none</em></div>\n" +
     "<dl ng-repeat=\"containerStatus in containerStatuses | orderBy:'name'\" class=\"dl-horizontal\">\n" +
     "  <dt>Name</dt>\n" +
-    "  <dd>{{containerStatus.name}}</dd>\n" +
+    "  <dd revealable-text>{{containerStatus.name}}</dd>\n" +
     "  <dt>State</dt>\n" +
     "  <dd>\n" +
     "    <kubernetes-object-describe-container-state container-state=\"containerStatus.state\"></container-state>\n" +
@@ -261,9 +250,9 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
     "<div ng-if=\"!containers.length\"><em>none</em></div>\n" +
     "<dl class=\"dl-horizontal\" ng-repeat=\"container in containers\">\n" +
     "<dt>Name</dt>\n" +
-    "<dd>{{container.name}}</dd>\n" +
+    "<dd revealable-text>{{container.name}}</dd>\n" +
     "<dt>Image</dt>\n" +
-    "<dd ng-if=\"container.image\">{{container.image}}</dd>\n" +
+    "<dd revealable-text ng-if=\"container.image\">{{container.image}}</dd>\n" +
     "<dd ng-if=\"!container.image\"><em>none</em></dd>\n" +
     "<dt>Ports</dt>\n" +
     "<dd>\n" +
@@ -275,7 +264,7 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
     "<dt>Env vars</dt>\n" +
     "<dd>\n" +
     "  <div ng-if=\"!container.env.length\"><em>none</em></div>\n" +
-    "  <div ng-repeat=\"env in container.env | orderBy:'name'\" collapse-long-text value=\"{{env.name}}={{env.value}}\"></div>\n" +
+    "  <div ng-repeat=\"env in container.env | orderBy:'name'\" revealable-text>{{env.name}}=<span ng-class=\"{masked: shouldMask(env.name)}\">{{env.value}}</span></div>\n" +
     "</dd>\n" +
     "</dl>\n" +
     "<div ng-if=\"$index != 0\" style=\"margin-bottom: 10px;\"></div>\n"

--- a/object-describer.js
+++ b/object-describer.js
@@ -141,7 +141,12 @@ angular.module('kubernetesUI')
     scope: {
       containers: '='
     },
-    templateUrl: 'views/containers.html'
+    templateUrl: 'views/containers.html',
+    link: function($scope, element, attrs) {
+      $scope.shouldMask = function(name) {
+          return name.toLowerCase().indexOf('password') !== -1;
+      };
+    }
   }
 })
 .directive("kubernetesObjectDescribeContainerStatuses", function() {
@@ -162,26 +167,19 @@ angular.module('kubernetesUI')
     templateUrl: 'views/container-state.html'
   };
 })
-.directive("collapseLongText", function() {
+.directive("revealableText", function() {
   return {
     restrict: 'A',
-    scope: {
-      value: '@',
-      enableCollapse: '=?' // not intended to be passed in, it will be set depending on jquery availability
-    },
-    controller: ["$scope", function($scope) {
-      // If jquery is available
-      $scope.enableCollapse = !!window.$;
-    }],
     link: function($scope, element, attrs) {
-      if ($scope.enableCollapse) {
-        $('.reveal-contents-link', element).click(function (evt) {
-          $(this).hide();
-          $('.reveal-contents', element).show();
-        });  
-      }
-    },    
-    templateUrl: 'views/_collapse-long-text.html'
+      element.addClass('revealable');
+      $(element).on("mouseover", function() {
+        var clickable = element[0].scrollWidth > element[0].clientWidth || element.find(".masked")[0];
+        element.toggleClass("clickable", clickable);
+      });
+      $(element).on("click", function() {
+        element.toggleClass("revealed");
+      });
+    }
   }
 })
 .filter("isEmptyObj", function() {

--- a/revealable.css
+++ b/revealable.css
@@ -1,0 +1,46 @@
+.revealable {
+    white-space: nowrap !important;
+    text-overflow: ellipsis;
+    overflow: hidden !important;
+}
+
+.revealable.clickable {
+    cursor: pointer;
+}
+
+.revealed {
+    white-space: normal !important;
+    overflow: visible !important;
+    cursor: pointer;
+    overflow-wrap: break-word;
+}
+
+.masked {
+    color: transparent;
+    position: relative;
+    text-ellipsis: none !important;
+    cursor: pointer;
+    max-width: 1;
+    display: inline-block;
+}
+
+.masked:after {
+    content: "●●●●";
+    position: absolute;
+    left: 0px;
+    font-weight: bold;
+    letter-spacing: 2px;
+    padding-left: 2px;
+    color: black;
+    cursor: pointer;
+    line-height: 1.5;
+    opacity: 0.5;
+}
+
+.revealed .masked:after {
+    display: none;
+}
+
+.revealed .masked {
+    color: black;
+}

--- a/views/_collapse-long-text.html
+++ b/views/_collapse-long-text.html
@@ -1,5 +1,0 @@
-<span ng-hide="enableCollapse && value.length > 120">{{value}}</span>
-<span ng-show="enableCollapse && value.length > 120">
-  <span class="reveal-contents-link" style="cursor: pointer;" title="Expand">{{value.substring(0, 120)}}<a href="javascript:;">...</a></span>
-  <span style="display: none;" class="reveal-contents">{{value}}</span>
-</span>

--- a/views/annotations.html
+++ b/views/annotations.html
@@ -2,5 +2,5 @@
   <span ng-if="!resource.metadata.annotations"><em>none</em></span>
   <dl class="dl-horizontal" ng-if="resource.metadata.annotations">
     <dt ng-repeat-start="(annotationKey, annotationValue) in resource.metadata.annotations" title="{{annotationKey}}">{{annotationKey}}</dt>
-    <dd ng-repeat-end collapse-long-text value="{{annotationValue}}"></dd>
+    <dd ng-repeat-end revealable-text>{{annotationValue}}</dd>
   </dl>

--- a/views/container-state.html
+++ b/views/container-state.html
@@ -1,5 +1,5 @@
 <span ng-if="containerState | isEmptyObj"><em>none</em></span>
-<span ng-repeat="(state, stateDescription) in containerState | limitTo: 1">
+<span ng-repeat="(state, stateDescription) in containerState | limitTo: 1" revealable-text>
   <span ng-switch="state">
     <span ng-switch-when="waiting">
       Waiting

--- a/views/container-statuses.html
+++ b/views/container-statuses.html
@@ -1,7 +1,7 @@
 <div ng-if="!containerStatuses"><em>none</em></div>
 <dl ng-repeat="containerStatus in containerStatuses | orderBy:'name'" class="dl-horizontal">
   <dt>Name</dt>
-  <dd>{{containerStatus.name}}</dd>
+  <dd revealable-text>{{containerStatus.name}}</dd>
   <dt>State</dt>
   <dd>
     <kubernetes-object-describe-container-state container-state="containerStatus.state"></container-state>

--- a/views/containers.html
+++ b/views/containers.html
@@ -1,9 +1,9 @@
 <div ng-if="!containers.length"><em>none</em></div>
 <dl class="dl-horizontal" ng-repeat="container in containers">
 <dt>Name</dt>
-<dd>{{container.name}}</dd>
+<dd revealable-text>{{container.name}}</dd>
 <dt>Image</dt>
-<dd ng-if="container.image">{{container.image}}</dd>
+<dd revealable-text ng-if="container.image">{{container.image}}</dd>
 <dd ng-if="!container.image"><em>none</em></dd>
 <dt>Ports</dt>
 <dd>
@@ -15,7 +15,7 @@
 <dt>Env vars</dt>
 <dd>
   <div ng-if="!container.env.length"><em>none</em></div>
-  <div ng-repeat="env in container.env | orderBy:'name'" collapse-long-text value="{{env.name}}={{env.value}}"></div>
+  <div ng-repeat="env in container.env | orderBy:'name'" revealable-text>{{env.name}}=<span ng-class="{masked: shouldMask(env.name)}">{{env.value}}</span></div>
 </dd>
 </dl>
 <div ng-if="$index != 0" style="margin-bottom: 10px;"></div>


### PR DESCRIPTION
Certain fields in the details pane must be ellipsized and then
expand themselves when clicked on. The ellipsizing should be
driven by the width of the field, not the number of characters.

Certain fields in the details pane should be masked as a courtesy,
such as password environment variables. Note that this does not
substitute for real security such as use of kubernetes secrets,
instead of environment variables.

Both ellipsized and masked fields are revealed in full when clicked on.

This patch includes an implementation of this behavior.

Some parts of this behavior are CSS driven, and an example CSS
file is included.
