### PR TITLE
Show defaults for some missing values

### DIFF
--- a/dist/object-describer.js
+++ b/dist/object-describer.js
@@ -348,7 +348,7 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
     "    <dt>Created</dt>\n" +
     "    <dd>{{resource.metadata.creationTimestamp | date:'medium'}}</dd>\n" +
     "    <dt>Restart policy</dt>\n" +
-    "    <dd>{{resource.spec.restartPolicy}}</dd>    \n" +
+    "    <dd>{{resource.spec.restartPolicy || 'Always'}}</dd>\n" +
     "  </dl>\n" +
     "  <h3>Status</h3>\n" +
     "  <dl class=\"dl-horizontal\">\n" +
@@ -358,12 +358,15 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
     "    <dd>{{resource.spec.host || 'unknown'}}\n" +
     "      <span ng-if=\"resource.status.hostIP && resource.spec.host != resource.status.hostIP\">({{resource.status.hostIP}})</dd>\n" +
     "    <dt>IP on node</dt>\n" +
-    "    <dd>{{resource.status.podIP}}</dd>    \n" +
+    "    <dd>\n" +
+    "      {{resource.status.podIP}}\n" +
+    "      <span ng-if=\"!resource.status.podIP\"><em>none</em></span>\n" +
+    "    </dd>\n" +
     "  </dl>\n" +
     "  <h3>Container Statuses</h3>\n" +
     "  <kubernetes-object-describe-container-statuses container-statuses=\"resource.status.containerStatuses\"></kubernetes-object-describe-container-statuses>\n" +
     "  <h3>Containers</h3>\n" +
-    "  <kubernetes-object-describe-containers containers=\"resource.spec.containers\"></kubernetes-object-describe-containers>  \n" +
+    "  <kubernetes-object-describe-containers containers=\"resource.spec.containers\"></kubernetes-object-describe-containers>\n" +
     "  <h3>Volumes</h3>\n" +
     "  <kubernetes-object-describe-volumes volumes=\"resource.spec.volumes\"></kubernetes-object-describe-volumes>\n" +
     "  <kubernetes-object-describe-labels resource=\"resource\"></kubernetes-object-describe-labels>\n" +
@@ -384,7 +387,8 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
     "    <dt>Created</dt>\n" +
     "    <dd>{{resource.metadata.creationTimestamp | date:'medium'}}</dd>\n" +
     "    <dt>Replicas</dt>\n" +
-    "    <dd>{{resource.spec.replicas}}</dd>\n" +
+    "    <!-- TODO: Update for API version v1. The default has changed from 0 to 1. -->\n" +
+    "    <dd>{{resource.spec.replicas || 0}}</dd>\n" +
     "  </dl>\n" +
     "  <h3>Selector</h3>\n" +
     "  <dl class=\"dl-horizontal\">\n" +

--- a/views/pod.html
+++ b/views/pod.html
@@ -8,7 +8,7 @@
     <dt>Created</dt>
     <dd>{{resource.metadata.creationTimestamp | date:'medium'}}</dd>
     <dt>Restart policy</dt>
-    <dd>{{resource.spec.restartPolicy}}</dd>    
+    <dd>{{resource.spec.restartPolicy || 'Always'}}</dd>
   </dl>
   <h3>Status</h3>
   <dl class="dl-horizontal">
@@ -18,12 +18,15 @@
     <dd>{{resource.spec.host || 'unknown'}}
       <span ng-if="resource.status.hostIP && resource.spec.host != resource.status.hostIP">({{resource.status.hostIP}})</dd>
     <dt>IP on node</dt>
-    <dd>{{resource.status.podIP}}</dd>    
+    <dd>
+      {{resource.status.podIP}}
+      <span ng-if="!resource.status.podIP"><em>none</em></span>
+    </dd>
   </dl>
   <h3>Container Statuses</h3>
   <kubernetes-object-describe-container-statuses container-statuses="resource.status.containerStatuses"></kubernetes-object-describe-container-statuses>
   <h3>Containers</h3>
-  <kubernetes-object-describe-containers containers="resource.spec.containers"></kubernetes-object-describe-containers>  
+  <kubernetes-object-describe-containers containers="resource.spec.containers"></kubernetes-object-describe-containers>
   <h3>Volumes</h3>
   <kubernetes-object-describe-volumes volumes="resource.spec.volumes"></kubernetes-object-describe-volumes>
   <kubernetes-object-describe-labels resource="resource"></kubernetes-object-describe-labels>

--- a/views/replication-controller.html
+++ b/views/replication-controller.html
@@ -8,7 +8,8 @@
     <dt>Created</dt>
     <dd>{{resource.metadata.creationTimestamp | date:'medium'}}</dd>
     <dt>Replicas</dt>
-    <dd>{{resource.spec.replicas}}</dd>
+    <!-- TODO: Update for API version v1. The default has changed from 0 to 1. -->
+    <dd>{{resource.spec.replicas || 0}}</dd>
   </dl>
   <h3>Selector</h3>
   <dl class="dl-horizontal">


### PR DESCRIPTION
- Default to `Always` when `restartPolicy` is not set on a pod
- Show 0 when `spec.replicas` is not set on a replication controller
- Show `none` when IP on node is not set in pod status
