### PR TITLE
Changing semantically neutral elements (<span>s and <div>s) to semant…

### DIFF
--- a/dist/object-describer.js
+++ b/dist/object-describer.js
@@ -204,16 +204,16 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
 
   $templateCache.put('views/annotations.html',
     "  <h3>Annotations</h3>\n" +
-    "  <span ng-if=\"!resource.metadata.annotations\"><em>none</em></span>\n" +
+    "  <p ng-if=\"!resource.metadata.annotations\"><em>none</em></p>\n" +
     "  <dl class=\"dl-horizontal\" ng-if=\"resource.metadata.annotations\">\n" +
     "    <dt ng-repeat-start=\"(annotationKey, annotationValue) in resource.metadata.annotations\" title=\"{{annotationKey}}\">{{annotationKey}}</dt>\n" +
     "    <dd ng-repeat-end collapse-long-text value=\"{{annotationValue}}\"></dd>\n" +
-    "  </dl>"
+    "  </dl>\n"
   );
 
 
   $templateCache.put('views/container-state.html',
-    "<span ng-if=\"containerState | isEmptyObj\"><em>none</em></span>\n" +
+    "<p ng-if=\"containerState | isEmptyObj\"><em>none</em></p>\n" +
     "<span ng-repeat=\"(state, stateDescription) in containerState | limitTo: 1\">\n" +
     "  <span ng-switch=\"state\">\n" +
     "    <span ng-switch-when=\"waiting\">\n" +
@@ -237,7 +237,7 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
 
 
   $templateCache.put('views/container-statuses.html',
-    "<div ng-if=\"!containerStatuses\"><em>none</em></div>\n" +
+    "<p ng-if=\"!containerStatuses\"><em>none</em></p>\n" +
     "<dl ng-repeat=\"containerStatus in containerStatuses | orderBy:'name'\" class=\"dl-horizontal\">\n" +
     "  <dt>Name</dt>\n" +
     "  <dd>{{containerStatus.name}}</dd>\n" +
@@ -258,7 +258,7 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
 
 
   $templateCache.put('views/containers.html',
-    "<div ng-if=\"!containers.length\"><em>none</em></div>\n" +
+    "<p ng-if=\"!containers.length\"><em>none</em></p>\n" +
     "<dl class=\"dl-horizontal\" ng-repeat=\"container in containers\">\n" +
     "<dt>Name</dt>\n" +
     "<dd>{{container.name}}</dd>\n" +
@@ -305,11 +305,11 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
 
   $templateCache.put('views/labels.html',
     "<h3>Labels</h3>\n" +
-    "<span ng-if=\"!resource.metadata.labels\"><em>none</em></span>\n" +
+    "<p ng-if=\"!resource.metadata.labels\"><em>none</em></p>\n" +
     "<dl class=\"dl-horizontal\" ng-if=\"resource.metadata.labels\">\n" +
     "  <dt ng-repeat-start=\"(labelKey, labelValue) in resource.metadata.labels\" title=\"{{labelKey}}\">{{labelKey}}</dt>\n" +
     "  <dd ng-repeat-end>{{labelValue}}</dd>\n" +
-    "</dl>"
+    "</dl>\n"
   );
 
 
@@ -453,7 +453,7 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
 
 
   $templateCache.put('views/volumes.html',
-    "<div ng-if=\"!volumes.length\"><em>none</em></div>\n" +
+    "<p ng-if=\"!volumes.length\"><em>none</em></p>\n" +
     "<dl class=\"dl-horizontal\" ng-repeat=\"volume in volumes\">\n" +
     "<dt>Name</dt>\n" +
     "<dd>{{volume.name}}</dd>\n" +
@@ -478,7 +478,7 @@ angular.module('kubernetesUI').run(['$templateCache', function($templateCache) {
     "  <span ng-if=\"volume.gitRepo.revision\">{{volume.gitRepo.revision}}</span>\n" +
     "  <span ng-if=\"!volume.gitRepo.revision\"><em>not specified</em></span>\n" +
     "</dd>\n" +
-    "</dl>"
+    "</dl>\n"
   );
 
 }]);

--- a/views/annotations.html
+++ b/views/annotations.html
@@ -1,5 +1,5 @@
   <h3>Annotations</h3>
-  <span ng-if="!resource.metadata.annotations"><em>none</em></span>
+  <p ng-if="!resource.metadata.annotations"><em>none</em></p>
   <dl class="dl-horizontal" ng-if="resource.metadata.annotations">
     <dt ng-repeat-start="(annotationKey, annotationValue) in resource.metadata.annotations" title="{{annotationKey}}">{{annotationKey}}</dt>
     <dd ng-repeat-end collapse-long-text value="{{annotationValue}}"></dd>

--- a/views/container-state.html
+++ b/views/container-state.html
@@ -1,4 +1,4 @@
-<span ng-if="containerState | isEmptyObj"><em>none</em></span>
+<p ng-if="containerState | isEmptyObj"><em>none</em></p>
 <span ng-repeat="(state, stateDescription) in containerState | limitTo: 1">
   <span ng-switch="state">
     <span ng-switch-when="waiting">

--- a/views/container-statuses.html
+++ b/views/container-statuses.html
@@ -1,4 +1,4 @@
-<div ng-if="!containerStatuses"><em>none</em></div>
+<p ng-if="!containerStatuses"><em>none</em></p>
 <dl ng-repeat="containerStatus in containerStatuses | orderBy:'name'" class="dl-horizontal">
   <dt>Name</dt>
   <dd>{{containerStatus.name}}</dd>

--- a/views/containers.html
+++ b/views/containers.html
@@ -1,4 +1,4 @@
-<div ng-if="!containers.length"><em>none</em></div>
+<p ng-if="!containers.length"><em>none</em></p>
 <dl class="dl-horizontal" ng-repeat="container in containers">
 <dt>Name</dt>
 <dd>{{container.name}}</dd>

--- a/views/labels.html
+++ b/views/labels.html
@@ -1,5 +1,5 @@
 <h3>Labels</h3>
-<span ng-if="!resource.metadata.labels"><em>none</em></span>
+<p ng-if="!resource.metadata.labels"><em>none</em></p>
 <dl class="dl-horizontal" ng-if="resource.metadata.labels">
   <dt ng-repeat-start="(labelKey, labelValue) in resource.metadata.labels" title="{{labelKey}}">{{labelKey}}</dt>
   <dd ng-repeat-end>{{labelValue}}</dd>

--- a/views/volumes.html
+++ b/views/volumes.html
@@ -1,4 +1,4 @@
-<div ng-if="!volumes.length"><em>none</em></div>
+<p ng-if="!volumes.length"><em>none</em></p>
 <dl class="dl-horizontal" ng-repeat="volume in volumes">
 <dt>Name</dt>
 <dd>{{volume.name}}</dd>


### PR DESCRIPTION
…ically meaningful  ones (&lt;p&gt;s).  Added bonus, &lt;p&gt;s have a margin on the bottom, so it’ll
give some separation between them and the content after them.

In OpenShift, this resolves ugliness like
![screen shot 2016-03-10 at 4 04 13 pm](https://cloud.githubusercontent.com/assets/895728/13684541/2a1cb2fe-e6da-11e5-860b-3e67b1953d9f.PNG)
so it looks like
![screen shot 2016-03-10 at 4 04 29 pm](https://cloud.githubusercontent.com/assets/895728/13684548/32c4bbe0-e6da-11e5-8a14-067a52698ffc.PNG)

@jwforres, PTAL.
